### PR TITLE
configure tabs as 2 spaces to avoid a dependency on global ruby defaults

### DIFF
--- a/ftdetect/vagrant.vim
+++ b/ftdetect/vagrant.vim
@@ -1,1 +1,1 @@
-au BufRead,BufNewFile Vagrantfile set filetype=ruby
+au BufRead,BufNewFile Vagrantfile set filetype=ruby tabstop=2 softtabstop=0 expandtab shiftwidth=2 smarttab


### PR DESCRIPTION
This is a small change, but I often have to work on ruby projects that have different spacing requirements.

I would prefer to keep the spacing for vagrant at the Hashicorp 2 space tab standard.

I have also modified the other repos.  If you accept this pull request and you want pull requests let me know.

Thank you for consolidating these tools in one place.